### PR TITLE
Force CultureInfo to "en-US"

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -15,6 +15,7 @@ namespace i3dm.export
     {
         static void Main(string[] args)
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
             Parser.Default.ParseArguments<Options>(args).WithParsed(o =>
             {
                 string tileFolder = "tiles";


### PR DESCRIPTION
Will prevent issues with string interpolation, when on systems where the decimal separator is a comma (French for instance), a number is turned into 2 parameters
Fixes https://github.com/Geodan/i3dm.export/issues/14