### PR TITLE
Get boundingvolume z from input table

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ Tool parameters:
 --max_features_per_tile (optional - default 1000). Maximum number of features/instances of tile
 
 --geometrycolumn: (optional - default: geom) Geometry column name
-
---boundingvolume_heights (option - default: 0,50) - Tile boundingVolume heights (min, max) in meters
 ```
 
 ## Sample running

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -42,9 +42,6 @@ public class Options
     [Option("max_features_per_tile", Required = false, Default = 1000, HelpText = "Maximum features per tile")]
     public int MaxFeaturesPerTile { get; set; }
 
-    [Option("boundingvolume_heights", Required = false, Default = "0,50", HelpText = "Tile boundingVolume heights (min, max) in meters")]
-    public string BoundingVolumeHeights { get; set; }
-
 }
 
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -36,14 +36,16 @@ class Program
 
             var conn = new NpgsqlConnection(o.ConnectionString);
             var epsg = o.Format == Format.Cesium ? 4978 : 3857;
-            var bbox_wgs84 = InstancesRepository.GetBoundingBoxForTable(conn, o.Table, geom_column, o.Query);
+            var bbox = InstancesRepository.GetBoundingBoxForTable(conn, o.Table, geom_column, o.Query);
+
+            var bbox_wgs84 = bbox.bbox;
+            var zmin = bbox.zmin;
+            var zmax = bbox.zmax;
+
             Console.WriteLine($"Bounding box for table (WGS84): {Math.Round(bbox_wgs84.XMin, 4)}, {Math.Round(bbox_wgs84.YMin, 4)}, {Math.Round(bbox_wgs84.XMax, 4)}, {Math.Round(bbox_wgs84.YMax, 4)}");
+            Console.WriteLine($"Vertical for table (meters): {zmin}, {zmax}");
 
-            var heightsArray = o.BoundingVolumeHeights.Split(',');
-            (double min, double max) heights = (double.Parse(heightsArray[0]), double.Parse(heightsArray[1]));
-            Console.WriteLine($"Heights for bounding volume: [{heights.min} m, {heights.max} m] ");
-
-            var rootBoundingVolumeRegion = bbox_wgs84.ToRadians().ToRegion(heights.min, heights.max);
+            var rootBoundingVolumeRegion = bbox_wgs84.ToRadians().ToRegion(zmin, zmax);
 
             var center_wgs84 = bbox_wgs84.GetCenter();
 

--- a/src/i3dm.export.csproj
+++ b/src/i3dm.export.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="cmpt-tile" Version="0.2.4" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Dapper" Version="2.0.151" />
+    <PackageReference Include="Dapper" Version="2.1.4" />
     <PackageReference Include="i3dm.tile" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql" Version="7.0.6" />


### PR DESCRIPTION
- Get boundingVolume z_min and z_max in tileset.json from input table (using st_3dextent)

- Removes option boundingvolume_heights 