### PR TITLE
fix jittering 

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 
 namespace i3dm.export;


### PR DESCRIPTION
fix jittering by storing relative positions instead of absolute ones.…The center position (first position) is stored in the node transformation